### PR TITLE
OAK-7569: Direct Binary Access

### DIFF
--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/core/MutableRoot.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/core/MutableRoot.java
@@ -26,14 +26,12 @@ import static org.apache.jackrabbit.oak.commons.PathUtils.isAncestor;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import javax.security.auth.Subject;
 
 import com.google.common.collect.ImmutableMap;
@@ -42,9 +40,6 @@ import org.apache.jackrabbit.oak.api.CommitFailedException;
 import org.apache.jackrabbit.oak.api.ContentSession;
 import org.apache.jackrabbit.oak.api.QueryEngine;
 import org.apache.jackrabbit.oak.api.Root;
-import org.apache.jackrabbit.oak.api.blob.HttpBlobUpload;
-import org.apache.jackrabbit.oak.api.blob.HttpBlobProvider;
-import org.apache.jackrabbit.oak.api.blob.IllegalHttpUploadArgumentsException;
 import org.apache.jackrabbit.oak.commons.PathUtils;
 import org.apache.jackrabbit.oak.plugins.index.diffindex.UUIDDiffIndexProviderWrapper;
 import org.apache.jackrabbit.oak.query.ExecutionContext;
@@ -71,7 +66,7 @@ import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
 import org.apache.jackrabbit.oak.spi.state.NodeState;
 import org.apache.jackrabbit.oak.spi.state.NodeStore;
 
-class MutableRoot implements Root, HttpBlobProvider {
+class MutableRoot implements Root {
 
     /**
      * The underlying store to which this root belongs
@@ -443,35 +438,6 @@ class MutableRoot implements Root, HttpBlobProvider {
                     ? "NIL"
                     : '>' + source + ':' + PathUtils.concat(destParent.getPathInternal(), destName);
         }
-    }
-
-    // HttpBlobProvider
-    @Nullable
-    @Override
-    public HttpBlobUpload initiateHttpUpload(long maxUploadSizeInBytes, int maxNumberOfUrls)
-            throws IllegalHttpUploadArgumentsException {
-        if (store instanceof HttpBlobProvider) {
-            return ((HttpBlobProvider) store).initiateHttpUpload(maxUploadSizeInBytes, maxNumberOfUrls);
-        }
-        return null;
-    }
-
-    @Nullable
-    @Override
-    public Blob completeHttpUpload(String uploadToken) {
-        if (store instanceof HttpBlobProvider) {
-            return ((HttpBlobProvider) store).completeHttpUpload(uploadToken);
-        }
-        return null;
-    }
-
-    @Nullable
-    @Override
-    public URL getHttpDownloadURL(String blobId) {
-        if (store instanceof HttpBlobProvider) {
-            return ((HttpBlobProvider) store).getHttpDownloadURL(blobId);
-        }
-        return null;
     }
 
 }

--- a/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/session/SessionImpl.java
+++ b/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/session/SessionImpl.java
@@ -63,7 +63,6 @@ import org.apache.jackrabbit.commons.xml.ParsingContentHandler;
 import org.apache.jackrabbit.commons.xml.SystemViewExporter;
 import org.apache.jackrabbit.commons.xml.ToXmlContentHandler;
 import org.apache.jackrabbit.oak.api.Blob;
-import org.apache.jackrabbit.oak.api.Root;
 import org.apache.jackrabbit.oak.api.Tree;
 import org.apache.jackrabbit.oak.api.blob.HttpBlobUpload;
 import org.apache.jackrabbit.oak.api.blob.HttpBlobProvider;
@@ -799,11 +798,7 @@ public class SessionImpl implements JackrabbitSession, HttpBinaryProvider {
             @Nullable
             @Override
             public HttpBinaryUpload performNullable() throws RepositoryException {
-                HttpBlobProvider httpBlobProvider = getHttpBlobProvider();
-                if (httpBlobProvider == null) {
-                    return null;
-                }
-
+                HttpBlobProvider httpBlobProvider = sessionContext.getHttpBlobProvider();
                 HttpBlobUpload upload = httpBlobProvider.initiateHttpUpload(maxSize, maxParts);
                 if (upload != null) {
                     return new HttpBinaryUpload() {
@@ -843,10 +838,7 @@ public class SessionImpl implements JackrabbitSession, HttpBinaryProvider {
             @Override
             public Binary perform() throws RepositoryException {
 
-                HttpBlobProvider httpBlobProvider = getHttpBlobProvider();
-                if (httpBlobProvider == null) {
-                    throw new RepositoryException("HTTP binary upload not supported");
-                }
+                HttpBlobProvider httpBlobProvider = sessionContext.getHttpBlobProvider();
                 Blob blob;
                 try {
                     blob = httpBlobProvider.completeHttpUpload(uploadToken);
@@ -872,10 +864,7 @@ public class SessionImpl implements JackrabbitSession, HttpBinaryProvider {
             @Nullable
             @Override
             public URL performNullable() throws RepositoryException {
-                HttpBlobProvider httpBlobProvider = getHttpBlobProvider();
-                if (httpBlobProvider == null) {
-                    return null;
-                }
+                HttpBlobProvider httpBlobProvider = sessionContext.getHttpBlobProvider();
                 if (binary instanceof ReferenceBinary) {
                     if (null == ((ReferenceBinary) binary).getReference()) {
                         // Binary is inlined, we cannot return a URL for it
@@ -893,15 +882,6 @@ public class SessionImpl implements JackrabbitSession, HttpBinaryProvider {
                 return null;
             }
         });
-    }
-
-    public HttpBlobProvider getHttpBlobProvider() {
-        Root root = sd.getRoot();
-        if (root instanceof HttpBlobProvider) {
-            return (HttpBlobProvider) root;
-        } else {
-            return null;
-        }
     }
 
     @Override

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/SegmentNodeStore.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/SegmentNodeStore.java
@@ -27,7 +27,6 @@ import static org.apache.jackrabbit.oak.api.Type.STRING;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URL;
 import java.util.Collections;
 import java.util.Map;
 
@@ -38,9 +37,6 @@ import javax.annotation.Nullable;
 import org.apache.jackrabbit.oak.api.Blob;
 import org.apache.jackrabbit.oak.api.CommitFailedException;
 import org.apache.jackrabbit.oak.api.PropertyState;
-import org.apache.jackrabbit.oak.api.blob.HttpBlobUpload;
-import org.apache.jackrabbit.oak.api.blob.HttpBlobProvider;
-import org.apache.jackrabbit.oak.api.blob.IllegalHttpUploadArgumentsException;
 import org.apache.jackrabbit.oak.plugins.blob.BlobStoreBlob;
 import org.apache.jackrabbit.oak.segment.scheduler.Commit;
 import org.apache.jackrabbit.oak.segment.scheduler.LockBasedScheduler;
@@ -64,7 +60,7 @@ import org.slf4j.LoggerFactory;
  * The root node of the JCR content tree is actually stored in the node "/root",
  * and checkpoints are stored under "/checkpoints".
  */
-public class SegmentNodeStore implements NodeStore, Observable, HttpBlobProvider {
+public class SegmentNodeStore implements NodeStore, Observable {
 
     public static class SegmentNodeStoreBuilder {
         private static final Logger LOG = LoggerFactory.getLogger(SegmentNodeStoreBuilder.class);
@@ -307,34 +303,5 @@ public class SegmentNodeStore implements NodeStore, Observable, HttpBlobProvider
     
     public SegmentNodeStoreStats getStats() {
         return stats;
-    }
-
-    // HttpBlobProvider
-    @Nullable
-    @Override
-    public HttpBlobUpload initiateHttpUpload(long maxUploadSizeInBytes, int maxNumberOfURLs)
-            throws IllegalHttpUploadArgumentsException {
-        if (blobStore instanceof HttpBlobProvider) {
-            return ((HttpBlobProvider) blobStore).initiateHttpUpload(maxUploadSizeInBytes, maxNumberOfURLs);
-        }
-        return null;
-    }
-
-    @Nullable
-    @Override
-    public Blob completeHttpUpload(String uploadToken) {
-        if (blobStore instanceof HttpBlobProvider) {
-            return ((HttpBlobProvider) blobStore).completeHttpUpload(uploadToken);
-        }
-        return null;
-    }
-
-    @Nullable
-    @Override
-    public URL getHttpDownloadURL(String blobId) {
-        if (blobStore instanceof HttpBlobProvider) {
-            return ((HttpBlobProvider) blobStore).getHttpDownloadURL(blobId);
-        }
-        return null;
     }
 }

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStore.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStore.java
@@ -46,7 +46,6 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.ref.WeakReference;
-import java.net.URL;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -83,18 +82,8 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.UncheckedExecutionException;
-import org.apache.jackrabbit.oak.api.Blob;
-import org.apache.jackrabbit.oak.api.CommitFailedException;
+
 import org.apache.jackrabbit.oak.api.PropertyState;
-import org.apache.jackrabbit.oak.api.blob.HttpBlobUpload;
-import org.apache.jackrabbit.oak.api.blob.HttpBlobProvider;
-import org.apache.jackrabbit.oak.api.blob.IllegalHttpUploadArgumentsException;
-import org.apache.jackrabbit.oak.cache.CacheStats;
-import org.apache.jackrabbit.oak.commons.PathUtils;
-import org.apache.jackrabbit.oak.commons.PerfLogger;
-import org.apache.jackrabbit.oak.commons.json.JsopStream;
-import org.apache.jackrabbit.oak.commons.json.JsopWriter;
-import org.apache.jackrabbit.oak.json.BlobSerializer;
 import org.apache.jackrabbit.oak.plugins.blob.BlobStoreBlob;
 import org.apache.jackrabbit.oak.plugins.blob.MarkSweepGarbageCollector;
 import org.apache.jackrabbit.oak.plugins.blob.ReferencedBlob;
@@ -104,12 +93,19 @@ import org.apache.jackrabbit.oak.plugins.document.bundlor.BundlingConfigHandler;
 import org.apache.jackrabbit.oak.plugins.document.bundlor.DocumentBundlor;
 import org.apache.jackrabbit.oak.plugins.document.persistentCache.PersistentCache;
 import org.apache.jackrabbit.oak.plugins.document.persistentCache.broadcast.DynamicBroadcastConfig;
+import org.apache.jackrabbit.oak.plugins.document.util.ReadOnlyDocumentStoreWrapperFactory;
+import org.apache.jackrabbit.oak.spi.blob.BlobStore;
+import org.apache.jackrabbit.oak.commons.json.JsopStream;
+import org.apache.jackrabbit.oak.commons.json.JsopWriter;
+import org.apache.jackrabbit.oak.api.Blob;
+import org.apache.jackrabbit.oak.api.CommitFailedException;
+import org.apache.jackrabbit.oak.cache.CacheStats;
+import org.apache.jackrabbit.oak.commons.PathUtils;
+import org.apache.jackrabbit.oak.json.BlobSerializer;
 import org.apache.jackrabbit.oak.plugins.document.util.LeaseCheckDocumentStoreWrapper;
 import org.apache.jackrabbit.oak.plugins.document.util.LoggingDocumentStoreWrapper;
-import org.apache.jackrabbit.oak.plugins.document.util.ReadOnlyDocumentStoreWrapperFactory;
 import org.apache.jackrabbit.oak.plugins.document.util.TimingDocumentStoreWrapper;
 import org.apache.jackrabbit.oak.plugins.document.util.Utils;
-import org.apache.jackrabbit.oak.spi.blob.BlobStore;
 import org.apache.jackrabbit.oak.spi.blob.GarbageCollectableBlobStore;
 import org.apache.jackrabbit.oak.spi.commit.ChangeDispatcher;
 import org.apache.jackrabbit.oak.spi.commit.CommitContext;
@@ -128,6 +124,7 @@ import org.apache.jackrabbit.oak.spi.state.NodeStateDiff;
 import org.apache.jackrabbit.oak.spi.state.NodeStore;
 import org.apache.jackrabbit.oak.spi.whiteboard.Whiteboard;
 import org.apache.jackrabbit.oak.stats.Clock;
+import org.apache.jackrabbit.oak.commons.PerfLogger;
 import org.apache.jackrabbit.oak.stats.StatisticsProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -136,7 +133,7 @@ import org.slf4j.LoggerFactory;
  * Implementation of a NodeStore on {@link DocumentStore}.
  */
 public final class DocumentNodeStore
-        implements NodeStore, RevisionContext, Observable, Clusterable, NodeStateDiffer, HttpBlobProvider {
+        implements NodeStore, RevisionContext, Observable, Clusterable, NodeStateDiffer {
 
     private static final Logger LOG = LoggerFactory.getLogger(DocumentNodeStore.class);
 
@@ -3299,34 +3296,5 @@ public final class DocumentNodeStore
 
     int getUpdateLimit() {
         return updateLimit;
-    }
-
-    // HttpBlobProvider
-    @Nullable
-    @Override
-    public HttpBlobUpload initiateHttpUpload(long maxUploadSizeInBytes, int maxNumberOfUrls)
-            throws IllegalHttpUploadArgumentsException {
-        if (blobStore instanceof HttpBlobProvider) {
-            return ((HttpBlobProvider) blobStore).initiateHttpUpload(maxUploadSizeInBytes, maxNumberOfUrls);
-        }
-        return null;
-    }
-
-    @Nullable
-    @Override
-    public Blob completeHttpUpload(String uploadToken) {
-        if (blobStore instanceof HttpBlobProvider) {
-            return ((HttpBlobProvider) blobStore).completeHttpUpload(uploadToken);
-        }
-        return null;
-    }
-
-    @Nullable
-    @Override
-    public URL getHttpDownloadURL(String blobId) {
-        if (blobStore instanceof HttpBlobProvider) {
-            return ((HttpBlobProvider) blobStore).getHttpDownloadURL(blobId);
-        }
-        return null;
     }
 }


### PR DESCRIPTION
Revert changes on MutableRoot, SegmentNodeStore and DocumentNodeStore
Wire HttpBlobProvider to the SessionContext using the Whiteboard
Use a default HttpBlobProvider implementation if none exists on the Whiteboard